### PR TITLE
Add new features to Pager

### DIFF
--- a/src/components/Pager/Pager.js
+++ b/src/components/Pager/Pager.js
@@ -10,27 +10,36 @@ export default class Pager extends React.Component {
     current: PropTypes.number.isRequired,
     hideLeftArrow: PropTypes.bool,
     hideRightArrow: PropTypes.bool,
+    textLeftArrow: PropTypes.oneOf([PropTypes.string, false]),
+    textRightArrow: PropTypes.oneOf([PropTypes.string, false]),
     onChange: PropTypes.func,
+    unlockChange: PropTypes.bool,
   }
 
   static defaultProps = {
     hideLeftArrow: false,
     hideRightArrow: false,
+    textLeftArrow: false,
+    textRightArrow: false,
     onChange: () => { },
+    unlockChange: false,
   }
 
   onPrevious = () => {
-    if (this.props.current === 0) {
-      return;
-    }
-    this.props.onChange(this.props.current - 1);
+    const { current, onChange, unlockChange } = this.props;
+    if (!unlockChange && current === 0) { return; }
+    onChange(current - 1);
   }
 
   onNext = () => {
-    if (this.props.current === this.props.steps - 1) {
-      return;
-    }
-    this.props.onChange(this.props.current + 1);
+    const {
+      current,
+      steps,
+      onChange,
+      unlockChange,
+    } = this.props;
+    if (!unlockChange && current === steps - 1) { return; }
+    onChange(current + 1);
   }
 
   steps() {
@@ -45,15 +54,23 @@ export default class Pager extends React.Component {
       current,
       hideLeftArrow,
       hideRightArrow,
+      textRightArrow,
+      textLeftArrow,
     } = this.props;
 
     return (
       <div className="ls-ui-kit pager">
-        <Icon type="left" className={hideLeftArrow && 'hidden'} onClick={this.onPrevious} />
+        { textLeftArrow === false
+          ? <Icon type="left" className={hideLeftArrow && 'hidden'} onClick={this.onPrevious} />
+          // eslint-disable-next-line
+          : <a role="link" onClick={this.onNext}>{textLeftArrow}</a> }
         <Steps progressDot current={current}>
           {this.steps()}
         </Steps>
-        <Icon type="right" className={hideRightArrow && 'hidden'} onClick={this.onNext} />
+        { textRightArrow === false
+          ? <Icon type="right" className={hideRightArrow && 'hidden'} onClick={this.onNext} />
+          // eslint-disable-next-line
+          : <a role="link" onClick={this.onNext}>{textRightArrow}</a> }
       </div>
     );
   }

--- a/stories/AntDefault/General/Pager/index.js
+++ b/stories/AntDefault/General/Pager/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Pager from '../../../../src/components/Pager';
 import WithState from '../../../utils/WithState';
+import { action } from '@storybook/addon-actions';
 
 export default () => (
   <div>
@@ -24,6 +25,16 @@ export default () => (
     <section className="example">
       <h2 className="ex-title">Default value</h2>
       <Pager steps={5} defaultValue={4} />
+    </section>
+
+    <section className="example">
+      <h2 className="ex-title">Text arrow overwrite</h2>
+      <Pager steps={5} defaultValue={4} textRightArrow="Next" textLeftArrow="Back" />
+    </section>
+
+    <section className="example">
+      <h2 className="ex-title">Unlock onChange</h2>
+      <Pager steps={5} defaultValue={4} unlockChange onChange={console.log} />
     </section>
 
     <section className="example">


### PR DESCRIPTION
- Add `unlockChange` to enable "unconstraining" of the onChange event
- add initial version of `textLeftArrow` and `textRightArrow`

At the moment the text versions aren't really working. I want to look at doing a `node` overwrite instead but I would need to work out how to best bind the onchange event onto the node that gets passed down. I'm thinking something along the lines of higher order components is what i need.