### PR TITLE
Attempt to fix search validation

### DIFF
--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -56,7 +56,7 @@ class SearchList extends Component {
     return this.props.onChange(value);
   }
 
-  error = v => (typeof v === 'undefined' ? this.setState({ error: false }) : this.setState({ error: v }));
+  error = v => (typeof v === 'undefined' ? this.setState({ error: null }) : this.setState({ error: v }));
 
   render() {
     const {
@@ -94,9 +94,6 @@ renderListItem.defaultProps = {
   icon: false,
 };
 
-// const isFalse = v => (v === false
-//  ? true
-//  : new Error(`Invalid prop ${v} supplied to Search, expected false`));
 SearchList.propTypes = {
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
@@ -109,7 +106,7 @@ SearchList.propTypes = {
   button: PropTypes.bool,
   renderItem: PropTypes.func,
   value: PropTypes.string,
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  error: PropTypes.string,
 };
 
 SearchList.defaultProps = {
@@ -124,7 +121,7 @@ SearchList.defaultProps = {
   button: true,
   renderItem: renderListItem,
   value: '',
-  error: false,
+  error: null,
 };
 
 export default SearchList;

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -94,6 +94,9 @@ renderListItem.defaultProps = {
   icon: false,
 };
 
+// const isFalse = v => (v === false
+//  ? true
+//  : new Error(`Invalid prop ${v} supplied to Search, expected false`));
 SearchList.propTypes = {
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
@@ -106,7 +109,7 @@ SearchList.propTypes = {
   button: PropTypes.bool,
   renderItem: PropTypes.func,
   value: PropTypes.string,
-  error: PropTypes.string,
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 };
 
 SearchList.defaultProps = {

--- a/stories/AntDefault/Data Entry/Search/index.js
+++ b/stories/AntDefault/Data Entry/Search/index.js
@@ -19,6 +19,15 @@ export const SearchMinInput = () => (
     <SearchList minInput={10} button={false} />
   </Fragment>);
 
+export const SearchError = () => (
+  <Fragment>
+    <h1>Search with error set</h1>
+    <SearchList error="This is an error" />
+    <h2>With error set to false</h2>
+    <SearchList error={false} />
+  </Fragment>
+);
+
 export const SearchLoading = () => (
   <Fragment>
     <h1>Search Loading</h1>

--- a/stories/AntDefault/Data Entry/Search/index.js
+++ b/stories/AntDefault/Data Entry/Search/index.js
@@ -23,8 +23,8 @@ export const SearchError = () => (
   <Fragment>
     <h1>Search with error set</h1>
     <SearchList error="This is an error" />
-    <h2>With error set to false</h2>
-    <SearchList error={false} />
+    <h2>With error set to null</h2>
+    <SearchList error={null} />
   </Fragment>
 );
 

--- a/stories/AntDefault/index.js
+++ b/stories/AntDefault/index.js
@@ -38,6 +38,7 @@ import TimePicker from './Data Entry/TimePicker';
 import Transfer from './Data Entry/Transfer';
 import {
   SearchMinInput,
+  SearchError,
   SearchOnChange,
   SearchOnSubmit,
   SearchLoading,
@@ -105,6 +106,7 @@ storiesOf('Liquid State UI Kit/Data Entry', module)
 
 storiesOf('Liquid State UI Kit/Data Entry/Search', module)
   .add('Minimun Input', () => <SearchMinInput />)
+  .add('Search Error', () => <SearchError />)
   .add('Loading', () => <SearchLoading />)
   .add('Heading', () => <SearchHeading />)
   .add('With Data', () => <SearchOnChange />)


### PR DESCRIPTION
Expand error validation to accept strings and booleans but this is too wide, should only accept strings and false.

- [x] Restrict error to only `string | null` or some other solution.