### PR TITLE
Add `Spinner` prop to override <Spin /> within Search.

### DIFF
--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -1,5 +1,11 @@
 import React, { Component } from 'react';
-import { List, Form, Input, Spin, Icon } from 'antd';
+import {
+  List,
+  Form,
+  Input,
+  Spin,
+  Icon,
+} from 'antd';
 import PropTypes from 'prop-types';
 
 import './style.less';
@@ -19,6 +25,8 @@ const renderListItem = onItemClick => item => (
     <span className="search-item-inner">{item.title}</span>
   </List.Item>
 );
+
+const renderLoading = () => (<Spin />);
 
 /**
  * SearchList Component
@@ -47,13 +55,13 @@ class SearchList extends Component {
 
   static getDerivedStateFromProps = (props, state) => ({
     ...state,
-    error: props.error,
-    value: props.value,
+    error: !state.error && props.error ? props.error : state.error,
   });
 
-  onSubmit = () => (this.state.value.length >= this.props.minInput
-    ? this.props.onSubmit(this.state.value)
-    : this.error());
+  onSubmit = () => {
+    const { state: { value }, props: { minInput, onSubmit }, error } = this;
+    return value.length >= minInput ? onSubmit(value) : error();
+  };
 
   onChange = ({ target: { value } }) => {
     const { minInput, onChange, onEmpty } = this.props;
@@ -68,11 +76,10 @@ class SearchList extends Component {
 
   render() {
     const {
-      results, button, renderItem, loading, onItemClick, heading, noResultsMessage,
+      results, button, renderItem, loading, onItemClick, heading, noResultsMessage, Spinner,
     } = this.props;
     const { error, value } = this.state;
     const help = error || (results.length === 0 && value !== '' ? noResultsMessage : null);
-
     return (
       <Form className="ls-ui-kit search">
         <Form.Item className="search-input-wrap" help={help}>
@@ -85,7 +92,7 @@ class SearchList extends Component {
         </Form.Item>
         { heading }
         { loading === true
-          ? <div className="search-spinner"><Spin /></div>
+          ? <div className="search-spinner"><Spinner /></div>
           : <List>{results.map(renderItem(onItemClick))}</List> }
       </Form>);
   }
@@ -114,6 +121,7 @@ SearchList.propTypes = {
   loading: PropTypes.bool,
   button: PropTypes.bool,
   renderItem: PropTypes.func,
+  Spinner: PropTypes.func,
   value: PropTypes.string,
   error: PropTypes.string,
 };
@@ -130,6 +138,7 @@ SearchList.defaultProps = {
   loading: false,
   button: true,
   renderItem: renderListItem,
+  Spinner: renderLoading,
   value: '',
   error: null,
 };

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -26,8 +26,6 @@ const renderListItem = onItemClick => item => (
   </List.Item>
 );
 
-const renderLoading = () => (<Spin />);
-
 /**
  * SearchList Component
  *
@@ -76,7 +74,7 @@ class SearchList extends Component {
 
   render() {
     const {
-      results, button, renderItem, loading, onItemClick, heading, noResultsMessage, Spinner,
+      results, button, renderItem, loading, onItemClick, heading, noResultsMessage, spinner,
     } = this.props;
     const { error, value } = this.state;
     const help = error || (results.length === 0 && value !== '' ? noResultsMessage : null);
@@ -92,7 +90,7 @@ class SearchList extends Component {
         </Form.Item>
         { heading }
         { loading === true
-          ? <div className="search-spinner"><Spinner /></div>
+          ? <div className="search-spinner">{ spinner }</div>
           : <List>{results.map(renderItem(onItemClick))}</List> }
       </Form>);
   }
@@ -121,7 +119,7 @@ SearchList.propTypes = {
   loading: PropTypes.bool,
   button: PropTypes.bool,
   renderItem: PropTypes.func,
-  Spinner: PropTypes.func,
+  spinner: PropTypes.node,
   value: PropTypes.string,
   error: PropTypes.string,
 };
@@ -138,7 +136,7 @@ SearchList.defaultProps = {
   loading: false,
   button: true,
   renderItem: renderListItem,
-  Spinner: renderLoading,
+  spinner: <Spin />,
   value: '',
   error: null,
 };

--- a/stories/AntDefault/Data Entry/Search/index.js
+++ b/stories/AntDefault/Data Entry/Search/index.js
@@ -38,7 +38,7 @@ export const SearchLoading = () => (
     <h2>Loading with results</h2>
     <SearchList results={exampleData} loading />
     <h2>Custom Spinner</h2>
-    <SearchList Spinner={() => <img src="///placehold.it/100x100" />} loading />
+    <SearchList spinner={<img src="///placehold.it/100x100" />} loading />
   </Fragment>);
 
 export const SearchHeading = () => (

--- a/stories/AntDefault/Data Entry/Search/index.js
+++ b/stories/AntDefault/Data Entry/Search/index.js
@@ -37,6 +37,8 @@ export const SearchLoading = () => (
     <hr />
     <h2>Loading with results</h2>
     <SearchList results={exampleData} loading />
+    <h2>Custom Spinner</h2>
+    <SearchList Spinner={() => <img src="///placehold.it/100x100" />} loading />
   </Fragment>);
 
 export const SearchHeading = () => (


### PR DESCRIPTION
Also fixes a bug caused by using getDerivedStateFromProps incorrectly.